### PR TITLE
feat: show on top of keyguard and dismiss lock screen on wake

### DIFF
--- a/app/src/main/java/com/aeonos/portalha/DashboardActivity.kt
+++ b/app/src/main/java/com/aeonos/portalha/DashboardActivity.kt
@@ -29,6 +29,19 @@ class DashboardActivity : AppCompatActivity() {
         // asserting HOME over us). HA's Screen switch can still sleep it —
         // this only blocks the timeout path, like a playing video does.
         window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        // Show on top of keyguard/lock screen and turn screen on when requested
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            @Suppress("DEPRECATION")
+            window.addFlags(
+                android.view.WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                android.view.WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+            )
+        }
+
         enableImmersive()   // kiosk: hide the system nav/status bars
 
         drawer = findViewById(R.id.drawer_layout)
@@ -130,6 +143,16 @@ class DashboardActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         enableImmersive()
+
+        // Dismiss the keyguard/lock screen so the dashboard is immediately interactive
+        val km = getSystemService(android.app.KeyguardManager::class.java)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            km.requestDismissKeyguard(this, null)
+        } else {
+            @Suppress("DEPRECATION")
+            window.addFlags(android.view.WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD)
+        }
+
         // Re-acquire the camera if another app (e.g. the Portal launcher) took
         // it while we were in the background.
         BridgeService.ensureCamera(this)


### PR DESCRIPTION
#### **Problem**
When using the app as a kiosk Home Assistant dashboard, turning the screen off (either via screen timeout, presence detection sleep, or the HA screen switch) and subsequently waking it up displays the system's lock/swipe screen. This disrupts the kiosk experience because the user must manually swipe to dismiss the keyguard and return to the dashboard.

#### **Solution**
This PR updates the main `DashboardActivity` to bypass the keyguard and automatically display the interactive dashboard immediately on wake:
1. **Window Flags (`onCreate`)**: Configured `setShowWhenLocked(true)` and `setTurnScreenOn(true)` (with backwards-compatible window flags for older APIs) to ensure the activity is rendered on top of the lock screen when the screen is turned on.
2. **Keyguard Dismissal (`onResume`)**: Acquired the `KeyguardManager` and called `requestDismissKeyguard` (falling back to `FLAG_DISMISS_KEYGUARD` on older versions) to automatically dismiss the swipe-to-unlock screen whenever the activity resumes.

#### **Files Modified**
* `app/src/main/java/com/aeonos/portalha/DashboardActivity.kt`