### PR TITLE
Add dashboard zoom slider to Display settings

### DIFF
--- a/app/src/main/java/com/aeonos/portalha/DashboardActivity.kt
+++ b/app/src/main/java/com/aeonos/portalha/DashboardActivity.kt
@@ -110,9 +110,11 @@ class DashboardActivity : AppCompatActivity() {
         webView.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView, url: String, favicon: android.graphics.Bitmap?) {
                 view.evaluateJavascript(alwaysVisibleJs(), null)
+                view.evaluateJavascript(zoomJs(), null)
             }
             override fun onPageFinished(view: WebView, url: String) {
                 view.evaluateJavascript(alwaysVisibleJs(), null)
+                view.evaluateJavascript(zoomJs(), null)
             }
             override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
                 handler.proceed() // Accept self-signed certs for local HA
@@ -213,6 +215,9 @@ class DashboardActivity : AppCompatActivity() {
         if (url.isNotEmpty() && !current.startsWith(normalise(url).trimEnd('/'))) {
             loadDashboard()
         }
+        // Re-apply the dashboard zoom so a change made in Display settings takes
+        // effect on return without needing a full reload.
+        webView.evaluateJavascript(zoomJs(), null)
     }
 
     // ── Intercom (push-to-announce) ───────────────────────────────────────────
@@ -314,6 +319,12 @@ class DashboardActivity : AppCompatActivity() {
      * the visibility events (capture phase, registered before HA's bundle loads)
      * keeps the streams connected across the handoff — no reload.
      */
+    // Applies a fixed CSS zoom to the whole dashboard so HA cards render bigger.
+    // Injected on page start + finish; the inline style on <html> survives HA's
+    // in-app (SPA) navigation and only needs re-applying on a full reload.
+    private fun zoomJs(): String =
+        "try{document.documentElement.style.zoom='${prefs.dashboardZoom}';}catch(e){}"
+
     private fun alwaysVisibleJs(): String = """
         (function () {
           if (window.__phaAlwaysVisible) return; window.__phaAlwaysVisible = true;

--- a/app/src/main/java/com/aeonos/portalha/DisplaySettingsActivity.kt
+++ b/app/src/main/java/com/aeonos/portalha/DisplaySettingsActivity.kt
@@ -30,6 +30,8 @@ class DisplaySettingsActivity : AppCompatActivity() {
     private lateinit var etMinutes: EditText
     private lateinit var tvPresenceStatus: TextView
     private lateinit var etTempOffset: EditText
+    private lateinit var seekDashboardZoom: SeekBar
+    private lateinit var tvDashboardZoom: TextView
     private var hasTempSensor = false
 
     // Live-sync the UI when the service changes prefs (HA commands).
@@ -50,6 +52,8 @@ class DisplaySettingsActivity : AppCompatActivity() {
     private fun soundLabel(threshold: Int) =
         "Sound threshold: $threshold" + if (liveLevel >= 0) "      (now: $liveLevel)" else ""
 
+    private fun zoomLabel(percent: Int) = "Dashboard zoom: $percent%"
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         prefs = Prefs(this)
@@ -69,6 +73,8 @@ class DisplaySettingsActivity : AppCompatActivity() {
         etMinutes = findViewById(R.id.et_timeout_minutes)
         tvPresenceStatus = findViewById(R.id.tv_presence_status)
         etTempOffset = findViewById(R.id.et_temp_offset)
+        seekDashboardZoom = findViewById(R.id.seek_dashboard_zoom)
+        tvDashboardZoom = findViewById(R.id.tv_dashboard_zoom)
 
         // The temperature section only makes sense on hardware that has the sensor.
         hasTempSensor = getSystemService(android.hardware.SensorManager::class.java)
@@ -148,6 +154,20 @@ class DisplaySettingsActivity : AppCompatActivity() {
             }
             override fun onStartTrackingTouch(bar: SeekBar) = Unit
             override fun onStopTrackingTouch(bar: SeekBar) { BridgeService.applyDisplaySettings(this@DisplaySettingsActivity) }
+        })
+
+        // Dashboard zoom: SeekBar carries the zoom as a percent (50–300%); the pref
+        // stores it as a float (0.5–3.0). Applied by DashboardActivity on its next
+        // onResume / page load — no service restart needed.
+        seekDashboardZoom.progress = (prefs.dashboardZoom * 100).toInt()
+        tvDashboardZoom.text = zoomLabel(seekDashboardZoom.progress)
+        seekDashboardZoom.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(bar: SeekBar, p: Int, fromUser: Boolean) {
+                tvDashboardZoom.text = zoomLabel(p)
+                if (fromUser) prefs.dashboardZoom = p / 100f
+            }
+            override fun onStartTrackingTouch(bar: SeekBar) = Unit
+            override fun onStopTrackingTouch(bar: SeekBar) = Unit
         })
 
         swTimeout.setOnCheckedChangeListener { _, checked ->
@@ -280,6 +300,10 @@ class DisplaySettingsActivity : AppCompatActivity() {
         if (seekPresenceSound.progress != prefs.presenceSoundThreshold)
             seekPresenceSound.progress = prefs.presenceSoundThreshold
         tvPresenceSound.text = soundLabel(prefs.presenceSoundThreshold)
+
+        val zoomPct = (prefs.dashboardZoom * 100).toInt()
+        if (seekDashboardZoom.progress != zoomPct) seekDashboardZoom.progress = zoomPct
+        tvDashboardZoom.text = zoomLabel(zoomPct)
         findViewById<View>(R.id.row_presence_sound).alpha =
             if (soundFeaturesAvailable && prefs.enhancedPresenceEnabled) 1f else 0.4f
 

--- a/app/src/main/java/com/aeonos/portalha/Prefs.kt
+++ b/app/src/main/java/com/aeonos/portalha/Prefs.kt
@@ -136,6 +136,12 @@ class Prefs(private val context: Context) {
         get() = sp.getBoolean("enhanced_presence", false)
         set(v) = sp.edit().putBoolean("enhanced_presence", v).apply()
 
+    // CSS zoom applied to the kiosk dashboard WebView. 1.0 = normal; >1 makes the
+    // HA cards (and everything else) proportionally bigger. Adjustable in Display settings.
+    var dashboardZoom: Float
+        get() = sp.getFloat("dashboard_zoom", 1.0f)
+        set(v) = sp.edit().putFloat("dashboard_zoom", v.coerceIn(0.5f, 3.0f)).apply()
+
     var presenceSoundThreshold: Int
         get() = sp.getInt("presence_sound_threshold", 8)
         set(v) = sp.edit().putInt("presence_sound_threshold", v.coerceIn(0, 100)).apply()

--- a/app/src/main/res/layout/activity_display_settings.xml
+++ b/app/src/main/res/layout/activity_display_settings.xml
@@ -34,6 +34,16 @@
                 android:layout_marginStart="16dp" />
         </LinearLayout>
 
+        <!-- Dashboard settings -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Dashboard settings"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textColor="@color/onSurface"
+            android:layout_marginBottom="8dp" />
+
         <!-- Dashboard zoom -->
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_display_settings.xml
+++ b/app/src/main/res/layout/activity_display_settings.xml
@@ -34,6 +34,29 @@
                 android:layout_marginStart="16dp" />
         </LinearLayout>
 
+        <!-- Dashboard zoom -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginBottom="24dp">
+
+            <TextView
+                android:id="@+id/tv_dashboard_zoom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Dashboard zoom"
+                android:textSize="13sp"
+                android:textColor="@color/onSurface" />
+
+            <SeekBar
+                android:id="@+id/seek_dashboard_zoom"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:min="50"
+                android:max="300" />
+        </LinearLayout>
+
         <!-- Portal Presence -->
         <Switch
             android:id="@+id/sw_presence"


### PR DESCRIPTION
## Summary

Adds a user-adjustable CSS zoom for the kiosk WebView so HA cards can render bigger for older eyes / further viewing distances. Controlled via a new SeekBar under a new **Dashboard settings** section in Display & Presence.

- `Prefs.dashboardZoom` — persists as float, coerced to `0.5f..3.0f`. Default `1.0f` (no-op — mergeable with zero visible change to existing installs).
- `DashboardActivity.zoomJs()` — a one-line `document.documentElement.style.zoom = X` injected on `onPageStarted` / `onPageFinished`, and re-applied in `onResume` so a change made in settings takes effect on return without a full reload.
- `DisplaySettingsActivity` — SeekBar wired to `prefs.dashboardZoom`, live label ("Dashboard zoom: N%"), synced in `updateUi` for HA-command-driven pref changes.
- Layout: new `Dashboard settings` section header + SeekBar (`android:min="50"`, `android:max="300"`).

## Notes
- Zero server-side / HA / MQTT surface changes. No new entities.
- Off-by-default (1.0), so no behavior change unless a user opens Display settings and moves the slider.
- Made with the help of Claude

## Test plan

- [x] Kotlin compile + assembleDebug clean
- [x] Slider renders in Display & Presence, label live-updates while dragging
- [x] `dashboard_zoom` float persists correctly in `portal_ha.xml`
- [x] Section title "Dashboard settings" sits above the slider, matching weight of other in-section headers
- [x] Verify CSS zoom takes effect on HA dashboard on Portal hardware (only tested on mini)